### PR TITLE
point source to "wearetechnative"

### DIFF
--- a/replication_source/role.tf
+++ b/replication_source/role.tf
@@ -1,5 +1,5 @@
 module "replication_role" {
-  source = "git@github.com:TechNative-B-V/terraform-aws-module-iam-role.git?ref=81c45f4d87bace3e990e64b92030292ac2fc480c"
+  source = "git@github.com:wearetechnative/terraform-aws-iam-role?ref=9a975f62956b6c4f2593c169d06d1cfe8aad36be"
 
   role_name = var.role_name
   role_path = var.role_path


### PR DESCRIPTION
They moved to wearetechnative for a reason, let's use the proper source.